### PR TITLE
Reduce description field in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,11 @@
 {
 	"manifest_version": 2,
 	"name": "Collapsed Mastodon",
-	"version": "0.6",
+	"version": "0.6.1",
 	"icons": {
 		"48": "icons/48.png"
 	},
-	"description": "Collapses the main Mastodon column for a cleaner view of the other timelines.\nShows small floating containers to write toots/make searchs and integrates replies below the target post.",
+	"description": "Collapses the main column of Mastodon for a cleaner view.\nMakes writing toots/searches easier by displaying a small container.",
 	"content_scripts": [ {
 		"matches": ["<all_urls>"],
 		"js": ["js/main.js"]


### PR DESCRIPTION
The current description size in the manifest is too long (183), it exceeds the maximum size limit of 132 characters in the chrome store,
this will reduce it down to within the accepted limit.